### PR TITLE
fix: Performance 카테고리 조회 시 distinct 조건 없어 limit 보다 데이터가 적게 조회되는 문제 발생…

### DIFF
--- a/src/main/java/com/heyticket/backend/repository/performance/PerformanceRepositoryImpl.java
+++ b/src/main/java/com/heyticket/backend/repository/performance/PerformanceRepositoryImpl.java
@@ -50,9 +50,10 @@ public class PerformanceRepositoryImpl implements PerformanceCustomRepository {
             .orderBy(orderCondition(request.getSortType(), request.getSortOrder()))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
+            .distinct()
             .fetch();
 
-        JPAQuery<Long> count = queryFactory.select(performance.count())
+        JPAQuery<Long> count = queryFactory.select(performance.id.countDistinct())
             .from(performance)
             .where(
                 inPrice(request),


### PR DESCRIPTION
…, queryDsl query에 distinct 추가, count query에 performance id로 countDistinct 추가